### PR TITLE
(Fix) Remove depreciated `current` region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,6 @@
 data "aws_caller_identity" "default" {}
 
-data "aws_region" "default" {
-  current = true
-}
+data "aws_region" "default" {}
 
 # Define composite variables for resources
 module "label" {


### PR DESCRIPTION
* Resolves depreciation warnings from Terraform:
> "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled