### PR TITLE
Add perms for SSM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,15 +106,16 @@ data "aws_iam_policy_document" "permissions" {
     sid = ""
 
     actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "ecr:BatchCheckLayerAvailability",
       "ecr:CompleteLayerUpload",
       "ecr:GetAuthorizationToken",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",
       "ecr:UploadLayerPart",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "ssm:GetParameters",
     ]
 
     effect = "Allow"


### PR DESCRIPTION
## what
Adds permission for `ssm:GetParameters` to the service role.

## why
Allows for pulling SSM secrets from codebuild specification.
https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-syntax