### PR TITLE
Add support for CodeBuild source location and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Available targets:
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `codebuild` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse' | string | `global` | no |
 | privileged_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
+| source_location | The location of the source code from git or s3. | string | `` | no |
+| source_type | The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3. | string | `CODEPIPELINE` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit', 'XYZ')` | map | `<map>` | no |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,6 +23,8 @@
 | privileged_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit', 'XYZ')` | map | `<map>` | no |
+| source_type | The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3. | string | `CODEPIPELINE` | no |
+| source_location | The location of the source code from git or s3. | string | `` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,10 +21,10 @@
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `codebuild` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse' | string | `global` | no |
 | privileged_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
+| source_location | The location of the source code from git or s3. | string | `` | no |
+| source_type | The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3. | string | `CODEPIPELINE` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit', 'XYZ')` | map | `<map>` | no |
-| source_type | The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3. | string | `CODEPIPELINE` | no |
-| source_location | The location of the source code from git or s3. | string | `` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ locals {
   cache_bucket_name_normalised = "${substr(join("-", split("_", lower(local.cache_bucket_name))), 0, min(length(local.cache_bucket_name),63))}"
 
   ## This is the magic where a map of a list of maps is generated
-  ## and used to conditionally add the cache bucket option to the 
+  ## and used to conditionally add the cache bucket option to the
   ## aws_codebuild_project
   cache_def = {
     "true" = [{
@@ -205,7 +205,8 @@ resource "aws_codebuild_project" "default" {
 
   source {
     buildspec = "${var.buildspec}"
-    type      = "CODEPIPELINE"
+    type      = "${var.source_type}"
+    location  = "${var.source_location}"
   }
 
   tags = "${module.label.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -122,3 +122,15 @@ variable "image_tag" {
   default     = "latest"
   description = "(Optional) Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
+
+variable "source_type" {
+  type        = "string"
+  default     = "CODEPIPELINE"
+  description = "(Required) The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3."
+}
+
+variable "source_location" {
+  type        = "string"
+  default     = ""
+  description = "(Optional) The location of the source code from git or s3."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -126,11 +126,11 @@ variable "image_tag" {
 variable "source_type" {
   type        = "string"
   default     = "CODEPIPELINE"
-  description = "(Required) The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3."
+  description = "The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3."
 }
 
 variable "source_location" {
   type        = "string"
   default     = ""
-  description = "(Optional) The location of the source code from git or s3."
+  description = "The location of the source code from git or s3."
 }


### PR DESCRIPTION
## what
* This adds support for specifying a location and type for the CodeBuild source

## why
*  To support building from sources other than CodePipeline, such as GitHub or S3.

## references
- <https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#type>
- <https://github.com/cloudposse/terraform-aws-codebuild/issues/21>
