### PR TITLE
Added permission to run ecs task to build policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "permissions" {
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
-      "ssm:GetParameters"
+      "ssm:GetParameters",
     ]
 
     effect = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ data "aws_iam_policy_document" "permissions" {
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "ssm:GetParameters",
+      "ecs:RunTask"
     ]
 
     effect = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -112,11 +112,11 @@ data "aws_iam_policy_document" "permissions" {
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",
       "ecr:UploadLayerPart",
+      "ecs:RunTask",
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
-      "ssm:GetParameters",
-      "ecs:RunTask"
+      "ssm:GetParameters"
     ]
 
     effect = "Allow"


### PR DESCRIPTION
Running one-off tasks during build process requires `ecs:RunTask` action. Ability to run such tasks is required for example when applying database migrations. This schema shows how it could be done with CircleCI: https://cdn-images-1.medium.com/max/800/1*eCVCawlDjC_nwIUYdLNxfQ.png