### PR TITLE
Added permission to pass IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ data "aws_iam_policy_document" "permissions" {
       "ecr:PutImage",
       "ecr:UploadLayerPart",
       "ecs:RunTask",
+      "iam:PassRole",
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",


### PR DESCRIPTION
Sorry for opening another PR, but to accomplish what was described here: https://github.com/cloudposse/terraform-aws-codebuild/pull/32 "iam:PassRole"`` is also required. This time, I have double checked and it should be enough.