### PR TITLE
Support pass-through for variable report_build_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Available targets:
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `codebuild` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse' | string | `global` | no |
 | privileged_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
+| report_build_status | Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the source_type is BITBUCKET or GITHUB. | string | `false` | no |
 | source_location | The location of the source code from git or s3. | string | `` | no |
 | source_type | The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3. | string | `CODEPIPELINE` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,6 +23,7 @@
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `codebuild` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse' | string | `global` | no |
 | privileged_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | string | `false` | no |
+| report_build_status | Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the source_type is BITBUCKET or GITHUB. | string | `false` | no |
 | source_location | The location of the source code from git or s3. | string | `` | no |
 | source_type | The type of repository that contains the source code to be built. Valid values for this parameter are: CODECOMMIT, CODEPIPELINE, GITHUB, GITHUB_ENTERPRISE, BITBUCKET or S3. | string | `CODEPIPELINE` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |

--- a/main.tf
+++ b/main.tf
@@ -160,11 +160,11 @@ resource "aws_iam_role_policy_attachment" "default_cache_bucket" {
 }
 
 resource "aws_codebuild_project" "default" {
-  count               = "${var.enabled == "true" ? 1 : 0}"
-  name                = "${module.label.id}"
-  service_role        = "${aws_iam_role.default.arn}"
-  badge_enabled       = "${var.badge_enabled}"
-  build_timeout       = "${var.build_timeout}"
+  count         = "${var.enabled == "true" ? 1 : 0}"
+  name          = "${module.label.id}"
+  service_role  = "${aws_iam_role.default.arn}"
+  badge_enabled = "${var.badge_enabled}"
+  build_timeout = "${var.build_timeout}"
 
   artifacts {
     type = "${var.artifact_type}"

--- a/main.tf
+++ b/main.tf
@@ -160,11 +160,12 @@ resource "aws_iam_role_policy_attachment" "default_cache_bucket" {
 }
 
 resource "aws_codebuild_project" "default" {
-  count         = "${var.enabled == "true" ? 1 : 0}"
-  name          = "${module.label.id}"
-  service_role  = "${aws_iam_role.default.arn}"
-  badge_enabled = "${var.badge_enabled}"
-  build_timeout = "${var.build_timeout}"
+  count               = "${var.enabled == "true" ? 1 : 0}"
+  name                = "${module.label.id}"
+  service_role        = "${aws_iam_role.default.arn}"
+  badge_enabled       = "${var.badge_enabled}"
+  build_timeout       = "${var.build_timeout}"
+  report_build_status = "${var.report_build_status}"
 
   artifacts {
     type = "${var.artifact_type}"

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,6 @@ resource "aws_codebuild_project" "default" {
   service_role        = "${aws_iam_role.default.arn}"
   badge_enabled       = "${var.badge_enabled}"
   build_timeout       = "${var.build_timeout}"
-  report_build_status = "${var.report_build_status}"
 
   artifacts {
     type = "${var.artifact_type}"
@@ -209,9 +208,10 @@ resource "aws_codebuild_project" "default" {
   }
 
   source {
-    buildspec = "${var.buildspec}"
-    type      = "${var.source_type}"
-    location  = "${var.source_location}"
+    buildspec           = "${var.buildspec}"
+    type                = "${var.source_type}"
+    location            = "${var.source_location}"
+    report_build_status = "${var.report_build_status}"
   }
 
   tags = "${module.label.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -152,3 +152,9 @@ variable "artifact_type" {
   default     = "CODEPIPELINE"
   description = "The build output artifact's type. Valid values for this parameter are: CODEPIPELINE, NO_ARTIFACTS or S3."
 }
+
+variable "report_build_status" {
+  type        = "string"
+  default     = "false"
+  description = "Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the source_type is BITBUCKET or GITHUB."
+}


### PR DESCRIPTION
# What

Exposes `report_build_status` as an external variable, defaulting to false.

PR includes updated README documentation.

# Why

This flag is useful for building out Github PR-verify workflows.