### PR TITLE
fix(output): Rename "role_arn" output to "role_id"

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Available targets:
 | project_id | Project ID |
 | project_name | Project name |
 | role_arn | IAM Role ARN |
+| role_id | IAM Role ID |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -38,4 +38,5 @@
 | project_id | Project ID |
 | project_name | Project name |
 | role_arn | IAM Role ARN |
+| role_id | IAM Role ID |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,9 +8,14 @@ output "project_id" {
   value       = "${join("", aws_codebuild_project.default.*.id)}"
 }
 
+output "role_id" {
+  description = "IAM Role ID"
+  value       = "${join("", aws_iam_role.default.*.id)}"
+}
+
 output "role_arn" {
   description = "IAM Role ARN"
-  value       = "${join("", aws_iam_role.default.*.id)}"
+  value       = "${join("", aws_iam_role.default.*.arn)}"
 }
 
 output "cache_bucket_name" {


### PR DESCRIPTION
Output `role_arn` was wrongly named, because it exposes "aws_iam_role.role.id" attribute
instead of "aws_iam_role.role.arn".

I've added both `role_arn` and `role_id`, because in my case I've needed
`role_arn`.

Note: This change is backwards incompatible, and will require changes
when making upgrade of modules using this module.

Example:
https://github.com/cloudposse/terraform-aws-ecs-codepipeline/blob/master/main.tf#L198

```diff
resource "aws_iam_role_policy_attachment" "codebuild_s3" {
  count      = "${local.enabled ? 1 : 0}"
-  role       = "${module.build.role_arn}"
+  role       = "${module.build.role_id}"
  policy_arn = "${aws_iam_policy.s3.arn}"
}
```
