### PR TITLE
Add bucket ARN output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-codebuild/releases).
+
+
 Include this module in your existing terraform code:
 
 ```hcl
@@ -148,6 +153,7 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | badge_url | The URL of the build badge when badge_enabled is enabled |
+| cache_bucket_arn | Cache S3 bucket ARN |
 | cache_bucket_name | Cache S3 bucket name |
 | project_id | Project ID |
 | project_name | Project name |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -34,6 +34,7 @@
 | Name | Description |
 |------|-------------|
 | badge_url | The URL of the build badge when badge_enabled is enabled |
+| cache_bucket_arn | Cache S3 bucket ARN |
 | cache_bucket_name | Cache S3 bucket name |
 | project_id | Project ID |
 | project_name | Project name |

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,11 @@ output "cache_bucket_name" {
   value       = "${var.enabled == "true" && var.cache_enabled == "true" ? join("", aws_s3_bucket.cache_bucket.*.bucket) : "UNSET" }"
 }
 
+output "cache_bucket_arn" {
+  description = "Cache S3 bucket ARN"
+  value       = "${var.enabled == "true" && var.cache_enabled == "true" ? join("", aws_s3_bucket.cache_bucket.*.arn) : "UNSET" }"
+}
+
 output "badge_url" {
   description = "The URL of the build badge when badge_enabled is enabled"
   value       = "${join("", aws_codebuild_project.default.*.badge_url)}"


### PR DESCRIPTION
In some cases (like interpolating the module's created bucket in another IAM policy) the ARN of the bucket is needed for interpolation. Adding output so that I don't have to use a data source to resolve the ARN from the bucket name.