### PR TITLE
Artifact location variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| artifact\_location | Location of artifact. Applies only for artifact of type S3 | `string` | `""` | no |
 | artifact\_type | The build output artifact's type. Valid values for this parameter are: CODEPIPELINE, NO\_ARTIFACTS or S3 | `string` | `"CODEPIPELINE"` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | (Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -22,6 +22,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| artifact\_location | Location of artifact. Applies only for artifact of type S3 | `string` | `""` | no |
 | artifact\_type | The build output artifact's type. Valid values for this parameter are: CODEPIPELINE, NO\_ARTIFACTS or S3 | `string` | `"CODEPIPELINE"` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | (Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,8 @@ resource "aws_codebuild_project" "default" {
   }
 
   artifacts {
-    type = var.artifact_type
+    type     = var.artifact_type
+    location = var.artifact_location
   }
 
   cache {

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,12 @@ variable "artifact_type" {
   description = "The build output artifact's type. Valid values for this parameter are: CODEPIPELINE, NO_ARTIFACTS or S3"
 }
 
+variable "artifact_location" {
+  type        = string
+  default     = ""
+  description = "Location of artifact. Applies only for artifact of type S3"
+}
+
 variable "report_build_status" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what

Added variable `artifact_location` and that is used for setting value of location of artifact of codebuild

## why

It is not possible to set artifact as `S3` without setting `location`.

