### PR TITLE
mfa_delete removed due to issue in terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Available targets:
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | local\_cache\_modes | Specifies settings that AWS CodeBuild uses to store and reuse build dependencies. Valid values: LOCAL\_SOURCE\_CACHE, LOCAL\_DOCKER\_LAYER\_CACHE, and LOCAL\_CUSTOM\_CACHE | `list(string)` | `[]` | no |
 | logs\_config | Configuration for the builds to store log data to CloudWatch or S3. | `any` | `{}` | no |
-| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | private\_repository | Set to true to login into private repository with credentials supplied in source\_credential variable. | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -50,7 +50,6 @@
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | local\_cache\_modes | Specifies settings that AWS CodeBuild uses to store and reuse build dependencies. Valid values: LOCAL\_SOURCE\_CACHE, LOCAL\_DOCKER\_LAYER\_CACHE, and LOCAL\_CUSTOM\_CACHE | `list(string)` | `[]` | no |
 | logs\_config | Configuration for the builds to store log data to CloudWatch or S3. | `any` | `{}` | no |
-| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | private\_repository | Set to true to login into private repository with credentials supplied in source\_credential variable. | `bool` | `false` | no |

--- a/examples/bitbucket/build.tf
+++ b/examples/bitbucket/build.tf
@@ -52,7 +52,4 @@ module "build" {
   attributes    = var.attributes
   tags          = var.tags
 
-
-
-
 }

--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -27,5 +27,3 @@ environment_variables = [
 cache_expiration_days = 7
 
 cache_type = "S3"
-
-mfa_delete = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,7 +8,6 @@ module "codebuild" {
   environment_variables       = var.environment_variables
   cache_expiration_days       = var.cache_expiration_days
   cache_type                  = var.cache_type
-  mfa_delete                  = var.mfa_delete
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -33,8 +33,3 @@ variable "cache_type" {
   type        = string
   description = "The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO_CACHE, LOCAL, and S3.  Defaults to NO_CACHE.  If cache_type is S3, it will create an S3 bucket for storing codebuild cache inside"
 }
-
-variable "mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-}

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ data "aws_region" "default" {
 resource "aws_s3_bucket" "cache_bucket" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
+  #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
   count         = module.this.enabled && local.s3_cache_enabled ? 1 : 0
   bucket        = local.cache_bucket_name_normalised
   acl           = "private"
@@ -14,8 +15,7 @@ resource "aws_s3_bucket" "cache_bucket" {
   tags          = module.this.tags
 
   versioning {
-    enabled    = var.versioning_enabled
-    mfa_delete = var.mfa_delete
+    enabled = var.versioning_enabled
   }
 
   dynamic "logging" {

--- a/variables.tf
+++ b/variables.tf
@@ -216,12 +216,6 @@ variable "versioning_enabled" {
   description = "A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket"
 }
 
-variable "mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-  default     = true
-}
-
 variable "access_log_bucket_name" {
   type        = string
   default     = ""


### PR DESCRIPTION
## what
* `mfa_delete` removed
* Bridgecrew check `Ensure S3 bucket has MFA delete enabled` skipped

## why
* Because terraform doesn't support this argument to be toggled (https://github.com/hashicorp/terraform-provider-aws/issues/629).
* To satisfy Bridgecrew compliance scan

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/629

