### PR TITLE
Add IAM policy permissions to allow CodeBuild to run in a VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,27 @@ Available targets:
 | aws | >= 2.0 |
 | random | >= 2.1 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_codebuild_project](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) |
+| [aws_codebuild_source_credential](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_source_credential) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -239,7 +260,6 @@ Available targets:
 | project\_name | Project name |
 | role\_arn | IAM Role ARN |
 | role\_id | IAM Role ID |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,27 @@
 | aws | >= 2.0 |
 | random | >= 2.1 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_codebuild_project](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) |
+| [aws_codebuild_source_credential](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_source_credential) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -82,5 +103,4 @@
 | project\_name | Project name |
 | role\_arn | IAM Role ARN |
 | role\_id | IAM Role ID |
-
 <!-- markdownlint-restore -->

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,0 +1,29 @@
+region = "us-east-2"
+
+namespace = "eg"
+
+stage = "test"
+
+name = "codebuild-test"
+
+cache_bucket_suffix_enabled = false
+
+environment_variables = [
+  {
+    name  = "APP_URL"
+    value = "https://app.example.com"
+  },
+  {
+    name  = "COMPANY_NAME"
+    value = "Cloud Posse"
+  },
+  {
+    name  = "TIME_ZONE"
+    value = "America/Los_Angeles"
+
+  }
+]
+
+cache_expiration_days = 7
+
+cache_type = "S3"

--- a/examples/vpc/context.tf
+++ b/examples/vpc/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/vpc/fixtures.us-east-2.tfvars
+++ b/examples/vpc/fixtures.us-east-2.tfvars
@@ -1,10 +1,14 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 
 stage = "test"
 
-name = "cedebuild-test"
+name = "codebuild-test"
+
+availability_zones = ["us-east-2a", "us-east-2b"]
+
+vpc_cidr_block = "172.16.0.0/16"
 
 cache_bucket_suffix_enabled = false
 

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -1,0 +1,44 @@
+provider "aws" {
+  region = var.region
+}
+
+module "vpc" {
+  source     = "cloudposse/vpc/aws"
+  version    = "0.21.1"
+  cidr_block = var.vpc_cidr_block
+
+  context = module.this.context
+}
+
+module "subnets" {
+  source               = "cloudposse/dynamic-subnets/aws"
+  version              = "0.38.0"
+  availability_zones   = var.availability_zones
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = true
+  nat_instance_enabled = false
+
+  context = module.this.context
+}
+
+module "codebuild" {
+  source                      = "../../"
+  cache_bucket_suffix_enabled = var.cache_bucket_suffix_enabled
+  environment_variables       = var.environment_variables
+  cache_expiration_days       = var.cache_expiration_days
+  cache_type                  = var.cache_type
+
+  vpc_config = {
+    vpc_id = module.vpc.vpc_id
+
+    subnets = module.subnets.private_subnet_ids
+
+    security_group_ids = [
+      module.vpc.vpc_default_security_group_id
+    ]
+  }
+
+  context = module.this.context
+}

--- a/examples/vpc/outputs.tf
+++ b/examples/vpc/outputs.tf
@@ -1,0 +1,49 @@
+output "public_subnet_cidrs" {
+  value       = module.subnets.public_subnet_cidrs
+  description = "Public subnet CIDRs"
+}
+
+output "private_subnet_cidrs" {
+  value       = module.subnets.private_subnet_cidrs
+  description = "Private subnet CIDRs"
+}
+
+output "vpc_cidr" {
+  value       = module.vpc.vpc_cidr_block
+  description = "VPC ID"
+}
+
+output "project_name" {
+  description = "Project name"
+  value       = module.codebuild.project_name
+}
+
+output "project_id" {
+  description = "Project ID"
+  value       = module.codebuild.project_id
+}
+
+output "role_id" {
+  description = "IAM Role ID"
+  value       = module.codebuild.role_id
+}
+
+output "role_arn" {
+  description = "IAM Role ARN"
+  value       = module.codebuild.role_arn
+}
+
+output "cache_bucket_name" {
+  description = "Cache S3 bucket name"
+  value       = module.codebuild.cache_bucket_name
+}
+
+output "cache_bucket_arn" {
+  description = "Cache S3 bucket ARN"
+  value       = module.codebuild.cache_bucket_arn
+}
+
+output "badge_url" {
+  description = "The URL of the build badge when badge_enabled is enabled"
+  value       = module.codebuild.badge_url
+}

--- a/examples/vpc/variables.tf
+++ b/examples/vpc/variables.tf
@@ -1,0 +1,45 @@
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones"
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  description = "VPC CIDR block"
+}
+
+variable "environment_variables" {
+  type = list(object(
+    {
+      name  = string
+      value = string
+  }))
+
+  default = [
+    {
+      name  = "NO_ADDITIONAL_BUILD_VARS"
+      value = "TRUE"
+  }]
+
+  description = "A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build"
+}
+
+variable "cache_expiration_days" {
+  type        = number
+  description = "How many days should the build cache be kept. It only works when cache_type is 'S3'"
+}
+
+variable "cache_bucket_suffix_enabled" {
+  type        = bool
+  description = "The cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value"
+}
+
+variable "cache_type" {
+  type        = string
+  description = "The type of storage that will be used for the AWS CodeBuild project cache. Valid values: NO_CACHE, LOCAL, and S3.  Defaults to NO_CACHE.  If cache_type is S3, it will create an S3 bucket for storing codebuild cache inside"
+}

--- a/main.tf
+++ b/main.tf
@@ -127,13 +127,6 @@ resource "aws_iam_policy" "default" {
   policy = data.aws_iam_policy_document.combined_permissions.json
 }
 
-# resource "aws_iam_policy" "vpc" {
-#   count  = module.this.enabled && var.vpc_config != {} ? 1 : 0
-#   name   = module.this.id
-#   path   = "/service-role/"
-#   policy = join("", data.aws_iam_policy_document.vpc_permissions.*.json)
-# }
-
 resource "aws_iam_policy" "default_cache_bucket" {
   count = module.this.enabled && local.s3_cache_enabled ? 1 : 0
 
@@ -254,12 +247,6 @@ resource "aws_iam_role_policy_attachment" "default" {
   policy_arn = join("", aws_iam_policy.default.*.arn)
   role       = join("", aws_iam_role.default.*.id)
 }
-
-# resource "aws_iam_role_policy_attachment" "vpc" {
-#   count      = module.this.enabled && var.vpc_config != {} ? 1 : 0
-#   policy_arn = join("", aws_iam_policy.vpc.*.arn)
-#   role       = join("", aws_iam_role.default.*.id)
-# }
 
 resource "aws_iam_role_policy_attachment" "default_cache_bucket" {
   count      = module.this.enabled && local.s3_cache_enabled ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ data "aws_iam_policy_document" "permissions" {
 }
 
 data "aws_iam_policy_document" "vpc_permissions" {
-  count = module.this.enabled && length(var.vpc_config) > 0 ? 1 : 0
+  count = module.this.enabled && length(keys(var.vpc_config)) > 0 ? 1 : 0
 
   statement {
     sid = ""

--- a/main.tf
+++ b/main.tf
@@ -165,6 +165,60 @@ data "aws_iam_policy_document" "permissions" {
   }
 }
 
+data "aws_iam_policy_document" "vpc_permissions" {
+  count = module.this.enabled && length(var.vpc_config) > 0 ? 1 : 0
+
+  statement {
+    sid = ""
+
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeDhcpOptions",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeVpcs"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+
+  statement {
+    sid = ""
+
+    actions = [
+      "ec2:CreateNetworkInterfacePermission"
+    ]
+
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:${var.aws_account_id}:network-interface/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:Subnet"
+      values = formatlist(
+        "arn:aws:ec2:${var.aws_region}:${var.aws_account_id}:subnet/%s",
+        var.vpc_config.subnets
+      )
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:AuthorizedService"
+      values = [
+        "codebuild.amazonaws.com"
+      ]
+    }
+
+  }
+}
+
+
 data "aws_iam_policy_document" "permissions_cache_bucket" {
   count = module.this.enabled && local.s3_cache_enabled ? 1 : 0
   statement {
@@ -340,4 +394,3 @@ resource "aws_codebuild_project" "default" {
     }
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ data "aws_iam_policy_document" "permissions" {
 }
 
 data "aws_iam_policy_document" "vpc_permissions" {
-  count = module.this.enabled && length(keys(var.vpc_config)) > 0 ? 1 : 0
+  count = module.this.enabled && var.vpc_config != {} ? 1 : 0
 
   statement {
     sid = ""

--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,13 @@ resource "aws_iam_policy" "default" {
   policy = data.aws_iam_policy_document.permissions.json
 }
 
+resource "aws_iam_policy" "vpc" {
+  count  = module.this.enabled && var.vpc_config != {} ? 1 : 0
+  name   = module.this.id
+  path   = "/service-role/"
+  policy = join("", data.aws_iam_policy_document.vpc_permissions.*.json)
+}
+
 resource "aws_iam_policy" "default_cache_bucket" {
   count = module.this.enabled && local.s3_cache_enabled ? 1 : 0
 
@@ -240,6 +247,12 @@ data "aws_iam_policy_document" "permissions_cache_bucket" {
 resource "aws_iam_role_policy_attachment" "default" {
   count      = module.this.enabled ? 1 : 0
   policy_arn = join("", aws_iam_policy.default.*.arn)
+  role       = join("", aws_iam_role.default.*.id)
+}
+
+resource "aws_iam_role_policy_attachment" "vpc" {
+  count      = module.this.enabled && var.vpc_config != {} ? 1 : 0
+  policy_arn = join("", aws_iam_policy.vpc.*.arn)
   role       = join("", aws_iam_role.default.*.id)
 }
 

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -17,6 +17,7 @@ init:
 test: init
 	go mod download
 	go test -v -timeout 60m -run TestExamplesComplete
+	go test -v -timeout 60m -run TestExamplesVPC
 
 ## Run tests in docker container
 docker/test:
@@ -27,4 +28,4 @@ docker/test:
 .PHONY : clean
 ## Clean up files
 clean:
-	rm -rf ../../examples/complete/*.tfstate*
+	rm -rf ../../examples/{complete,vpc}/*.tfstate*

--- a/test/src/examples_vpc_test.go
+++ b/test/src/examples_vpc_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Test the Terraform module in examples/complete using Terratest.
-func TestExamplesComplete(t *testing.T) {
+func TestExamplesVPC(t *testing.T) {
 	t.Parallel()
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
-		TerraformDir: "../../examples/complete",
+		TerraformDir: "../../examples/vpc",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
@@ -32,10 +32,4 @@ func TestExamplesComplete(t *testing.T) {
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedProjectName, projectName)
 
-	// Run `terraform output` to get the value of an output variable
-	cacheS3BucketName := terraform.Output(t, terraformOptions, "cache_bucket_name")
-
-	expectedCacheS3BucketName := "eg-test-codebuild-test"
-	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedCacheS3BucketName, cacheS3BucketName)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -186,6 +186,7 @@ variable "fetch_git_submodules" {
   description = "If set to true, fetches Git submodules for the AWS CodeBuild build project."
 }
 
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project#vpc_config
 variable "vpc_config" {
   type        = any
   default     = {}


### PR DESCRIPTION
## what
* Update IAM permissions in Codebuild policy to allow running in a VPC
* Add a test using VPC config
* Change test region to us-east-2
* (There is probably a more elegant way to check if var.vpc_config is an empty object but I didn't find one in the time I spent looking.)

## why
* The module supported setting VPC config on the Codebuild project, but the IAM permissions in the Codebuild policy were not sufficient

## references
* None

