### PR TITLE
S3 secondary artifact integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Available targets:
 | secondary\_artifact\_encryption\_enabled | Set to true to enable encryption on the secondary artifact bucket | `bool` | `false` | no |
 | secondary\_artifact\_identifier | Secondary artifact identifier. Must match the identifier in the build spec | `string` | `null` | no |
 | secondary\_artifact\_location | Location of secondary artifact. Must be an S3 reference | `string` | `null` | no |
+| secondary\_sources | (Optional) secondary source for the codebuild project in addition to the primary location | <pre>list(object(<br>    {<br>      git_clone_depth     = number<br>      location            = string<br>      source_identifier   = string<br>      type                = string<br>      fetch_submodules    = bool<br>      insecure_ssl        = bool<br>      report_build_status = bool<br>  }))</pre> | `[]` | no |
 | source\_credential\_auth\_type | The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. | `string` | `"PERSONAL_ACCESS_TOKEN"` | no |
 | source\_credential\_server\_type | The source provider used for this project. | `string` | `"GITHUB"` | no |
 | source\_credential\_token | For GitHub or GitHub Enterprise, this is the personal access token. For Bitbucket, this is the app password. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ Available targets:
 | secondary\_artifact\_encryption\_enabled | Set to true to enable encryption on the secondary artifact bucket | `bool` | `false` | no |
 | secondary\_artifact\_identifier | Secondary artifact identifier. Must match the identifier in the build spec | `string` | `null` | no |
 | secondary\_artifact\_location | Location of secondary artifact. Must be an S3 reference | `string` | `null` | no |
-| secondary\_sources | (Optional) secondary source for the codebuild project in addition to the primary location | <pre>list(object(<br>    {<br>      git_clone_depth     = number<br>      location            = string<br>      source_identifier   = string<br>      type                = string<br>      fetch_submodules    = bool<br>      insecure_ssl        = bool<br>      report_build_status = bool<br>  }))</pre> | `[]` | no |
 | source\_credential\_auth\_type | The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. | `string` | `"PERSONAL_ACCESS_TOKEN"` | no |
 | source\_credential\_server\_type | The source provider used for this project. | `string` | `"GITHUB"` | no |
 | source\_credential\_token | For GitHub or GitHub Enterprise, this is the personal access token. For Bitbucket, this is the app password. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Available targets:
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
 | [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
 | [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) |
 
@@ -203,7 +204,6 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | (Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
 | aws\_region | (Optional) AWS Region, e.g. us-east-1. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
 | badge\_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge\_url attribute when enabled | `bool` | `false` | no |
 | build\_compute\_type | Instance type of the build instance | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | build\_image | Docker image for build environment, e.g. 'aws/codebuild/standard:2.0' or 'aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html | `string` | `"aws/codebuild/standard:2.0"` | no |

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | (Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
 | aws\_region | (Optional) AWS Region, e.g. us-east-1. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
 | badge\_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge\_url attribute when enabled | `bool` | `false` | no |
 | build\_compute\_type | Instance type of the build instance | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | build\_image | Docker image for build environment, e.g. 'aws/codebuild/standard:2.0' or 'aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html | `string` | `"aws/codebuild/standard:2.0"` | no |
@@ -236,6 +237,9 @@ Available targets:
 | privileged\_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | `bool` | `false` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | report\_build\_status | Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the source\_type is BITBUCKET or GITHUB | `bool` | `false` | no |
+| secondary\_artifact\_encryption\_enabled | Set to true to enable encryption on the secondary artifact bucket | `bool` | `false` | no |
+| secondary\_artifact\_identifier | Secondary artifact identifier. Must match the identifier in the build spec | `string` | `null` | no |
+| secondary\_artifact\_location | Location of secondary artifact. Must be an S3 reference | `string` | `null` | no |
 | source\_credential\_auth\_type | The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. | `string` | `"PERSONAL_ACCESS_TOKEN"` | no |
 | source\_credential\_server\_type | The source provider used for this project. | `string` | `"GITHUB"` | no |
 | source\_credential\_token | For GitHub or GitHub Enterprise, this is the personal access token. For Bitbucket, this is the app password. | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,6 +32,7 @@
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
 | [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
 | [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) |
 
@@ -46,7 +47,6 @@
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | (Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
 | aws\_region | (Optional) AWS Region, e.g. us-east-1. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
 | badge\_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge\_url attribute when enabled | `bool` | `false` | no |
 | build\_compute\_type | Instance type of the build instance | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | build\_image | Docker image for build environment, e.g. 'aws/codebuild/standard:2.0' or 'aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html | `string` | `"aws/codebuild/standard:2.0"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -80,6 +80,9 @@
 | privileged\_mode | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images | `bool` | `false` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | report\_build\_status | Set to true to report the status of a build's start and finish to your source provider. This option is only valid when the source\_type is BITBUCKET or GITHUB | `bool` | `false` | no |
+| secondary\_artifact\_encryption\_enabled | Set to true to enable encryption on the secondary artifact bucket | `bool` | `false` | no |
+| secondary\_artifact\_identifier | Secondary artifact identifier. Must match the identifier in the build spec | `string` | `null` | no |
+| secondary\_artifact\_location | Location of secondary artifact. Must be an S3 reference | `string` | `null` | no |
 | source\_credential\_auth\_type | The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. | `string` | `"PERSONAL_ACCESS_TOKEN"` | no |
 | source\_credential\_server\_type | The source provider used for this project. | `string` | `"GITHUB"` | no |
 | source\_credential\_token | For GitHub or GitHub Enterprise, this is the personal access token. For Bitbucket, this is the app password. | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -83,6 +83,7 @@
 | secondary\_artifact\_encryption\_enabled | Set to true to enable encryption on the secondary artifact bucket | `bool` | `false` | no |
 | secondary\_artifact\_identifier | Secondary artifact identifier. Must match the identifier in the build spec | `string` | `null` | no |
 | secondary\_artifact\_location | Location of secondary artifact. Must be an S3 reference | `string` | `null` | no |
+| secondary\_sources | (Optional) secondary source for the codebuild project in addition to the primary location | <pre>list(object(<br>    {<br>      git_clone_depth     = number<br>      location            = string<br>      source_identifier   = string<br>      type                = string<br>      fetch_submodules    = bool<br>      insecure_ssl        = bool<br>      report_build_status = bool<br>  }))</pre> | `[]` | no |
 | source\_credential\_auth\_type | The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. | `string` | `"PERSONAL_ACCESS_TOKEN"` | no |
 | source\_credential\_server\_type | The source provider used for this project. | `string` | `"GITHUB"` | no |
 | source\_credential\_token | For GitHub or GitHub Enterprise, this is the personal access token. For Bitbucket, this is the app password. | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -46,6 +46,7 @@
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | aws\_account\_id | (Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
 | aws\_region | (Optional) AWS Region, e.g. us-east-1. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html | `string` | `""` | no |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
 | badge\_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge\_url attribute when enabled | `bool` | `false` | no |
 | build\_compute\_type | Instance type of the build instance | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | build\_image | Docker image for build environment, e.g. 'aws/codebuild/standard:2.0' or 'aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html | `string` | `"aws/codebuild/standard:2.0"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -83,7 +83,6 @@
 | secondary\_artifact\_encryption\_enabled | Set to true to enable encryption on the secondary artifact bucket | `bool` | `false` | no |
 | secondary\_artifact\_identifier | Secondary artifact identifier. Must match the identifier in the build spec | `string` | `null` | no |
 | secondary\_artifact\_location | Location of secondary artifact. Must be an S3 reference | `string` | `null` | no |
-| secondary\_sources | (Optional) secondary source for the codebuild project in addition to the primary location | <pre>list(object(<br>    {<br>      git_clone_depth     = number<br>      location            = string<br>      source_identifier   = string<br>      type                = string<br>      fetch_submodules    = bool<br>      insecure_ssl        = bool<br>      report_build_status = bool<br>  }))</pre> | `[]` | no |
 | source\_credential\_auth\_type | The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. | `string` | `"PERSONAL_ACCESS_TOKEN"` | no |
 | source\_credential\_server\_type | The source provider used for this project. | `string` | `"GITHUB"` | no |
 | source\_credential\_token | For GitHub or GitHub Enterprise, this is the personal access token. For Bitbucket, this is the app password. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,6 @@ data "aws_caller_identity" "default" {
 data "aws_region" "default" {
 }
 
-data "aws_s3_bucket" "secondary_artifact" {
-  count  = module.this.enabled ? (var.secondary_artifact_location != null ? 1 : 0) : 0
-  bucket = var.secondary_artifact_location
-}
-
 resource "aws_s3_bucket" "cache_bucket" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
@@ -141,7 +136,14 @@ resource "aws_iam_policy" "default_cache_bucket" {
   policy = join("", data.aws_iam_policy_document.permissions_cache_bucket.*.json)
 }
 
+data "aws_s3_bucket" "secondary_artifact" {
+  count  = module.this.enabled ? (var.secondary_artifact_location != null ? 1 : 0) : 0
+  bucket = var.secondary_artifact_location
+}
+
 data "aws_iam_policy_document" "permissions" {
+  count = module.this.enabled ? 1 : 0
+
   statement {
     sid = ""
 
@@ -167,6 +169,26 @@ data "aws_iam_policy_document" "permissions" {
     resources = [
       "*",
     ]
+  }
+
+  dynamic "statement" {
+    for_each = var.secondary_artifact_location != null ? [1] : []
+    content {
+      sid = ""
+
+      actions = [
+        "s3:PutObject",
+        "s3:GetBucketAcl",
+        "s3:GetBucketLocation"
+      ]
+
+      effect = "Allow"
+
+      resources = [
+        join("", data.aws_s3_bucket.secondary_artifact.*.arn),
+        "${join("", data.aws_s3_bucket.secondary_artifact.*.arn)}/*",
+      ]
+    }
   }
 }
 
@@ -224,7 +246,7 @@ data "aws_iam_policy_document" "vpc_permissions" {
 
 data "aws_iam_policy_document" "combined_permissions" {
   override_policy_documents = compact([
-    data.aws_iam_policy_document.permissions.json,
+    join("", data.aws_iam_policy_document.permissions.*.json),
     var.vpc_config != {} ? join("", data.aws_iam_policy_document.vpc_permissions.*.json) : null
   ])
 }
@@ -283,6 +305,30 @@ resource "aws_codebuild_project" "default" {
   artifacts {
     type     = var.artifact_type
     location = var.artifact_location
+  }
+
+  # Since the output type is restricted to S3 by the provider (this appears to
+  # be an bug in AWS, rather than an architectural decision; see this issue for
+  # discussion: https://github.com/hashicorp/terraform-provider-aws/pull/9652),
+  # this cannot be a CodePipeline output. Otherwise, _all_ of the artifacts
+  # would need to be secondary if there were more than one. For reference, see
+  # https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodeBuild.html#action-reference-CodeBuild-config.
+  dynamic "secondary_artifacts" {
+    for_each = var.secondary_artifact_location != null ? [1] : []
+    content {
+      type                = "S3"
+      location            = var.secondary_artifact_location
+      artifact_identifier = var.secondary_artifact_identifier
+      encryption_disabled = !var.secondary_artifact_encryption_enabled
+      # According to AWS documention, in order to have the artifacts written
+      # to the root of the bucket, the 'namespace_type' should be 'NONE'
+      # (which is the default), 'name' should be '/', and 'path' should be
+      # empty. For reference, see https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectArtifacts.html.
+      # However, I was unable to get this to deploy to the root of the bucket
+      # unless path was also set to '/'.
+      path = "/"
+      name = "/"
+    }
   }
 
   cache {

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,11 @@ data "aws_caller_identity" "default" {
 data "aws_region" "default" {
 }
 
+data "aws_s3_bucket" "secondary_artifact" {
+  count  = module.this.enabled ? (var.secondary_artifact_location != null ? 1 : 0) : 0
+  bucket = var.secondary_artifact_location
+}
+
 resource "aws_s3_bucket" "cache_bucket" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).

--- a/main.tf
+++ b/main.tf
@@ -319,7 +319,7 @@ resource "aws_codebuild_project" "default" {
       type                = "S3"
       location            = var.secondary_artifact_location
       artifact_identifier = var.secondary_artifact_identifier
-      encryption_disabled = !var.secondary_artifact_encryption_enabled
+      encryption_disabled = ! var.secondary_artifact_encryption_enabled
       # According to AWS documention, in order to have the artifacts written
       # to the root of the bucket, the 'namespace_type' should be 'NONE'
       # (which is the default), 'name' should be '/', and 'path' should be

--- a/variables.tf
+++ b/variables.tf
@@ -132,6 +132,24 @@ variable "artifact_location" {
   description = "Location of artifact. Applies only for artifact of type S3"
 }
 
+variable "secondary_artifact_location" {
+  type        = string
+  default     = null
+  description = "Location of secondary artifact. Must be an S3 reference"
+}
+
+variable "secondary_artifact_identifier" {
+  type        = string
+  default     = null
+  description = "Secondary artifact identifier. Must match the identifier in the build spec"
+}
+
+variable "secondary_artifact_encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "Set to true to enable encryption on the secondary artifact bucket"
+}
+
 variable "report_build_status" {
   type        = bool
   default     = false


### PR DESCRIPTION
Fixes #77.

what
Adds an optional secondary artifact deployment to S3
why
Allow the https://github.com/cloudposse/terraform-aws-ecs-web-app module to use the changes for a lightweight deployment of assets for an S3-backed CDN
references
Closes #77

