### PR TITLE
Add support for path and permissions_boundary to IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,8 @@ resource "aws_iam_role" "default" {
   name                  = module.this.id
   assume_role_policy    = data.aws_iam_policy_document.role.json
   force_detach_policies = true
+  path                  = var.iam_role_path
+  permissions_boundary  = var.iam_permissions_boundary
   tags                  = module.this.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -246,6 +246,18 @@ variable "extra_permissions" {
   description = "List of action strings which will be added to IAM service account permissions."
 }
 
+variable "iam_role_path" {
+  type        = string
+  default     = null
+  description = "Path to the role."
+}
+
+variable "iam_permissions_boundary" {
+  type        = string
+  default     = null
+  description = "ARN of the policy that is used to set the permissions boundary for the role."
+}
+
 variable "encryption_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Add support for path and permissions_boundary to IAM role

## why
* We use path and permissions_boundary to limit IAM role creation

