### PR TITLE
Allow AWS_REGION on input variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -345,9 +345,12 @@ resource "aws_codebuild_project" "default" {
     type            = var.build_type
     privileged_mode = var.privileged_mode
 
-    environment_variable {
-      name  = "AWS_REGION"
-      value = signum(length(var.aws_region)) == 1 ? var.aws_region : data.aws_region.default.name
+    dynamic "environment_variable" {
+      for_each = signum(length(var.aws_account_id)) == 0 && contains(var.environment_variables.*.name, "AWS_REGION") ? [] : [1]
+      content {
+        name  = "AWS_REGION"
+        value = signum(length(var.aws_region)) == 1 ? var.aws_region : data.aws_region.default.name
+      }
     }
 
     environment_variable {


### PR DESCRIPTION
## what
* Allow passing `AWS_REGION` on input `environment_variables`

## why
* Passing `AWS_REGION` as environment variable on module input causes an error
```
Error creating CodeBuild project: InvalidInputException: EnvironmentVariable name cannot be duplicated
```
* Our organization needs to to run the application on a Codebuild task copying the environment variables values from production instance. However, the production environment already contains a `AWS_REGION` variable.

Thank you

