### PR TITLE
S3 resource supports AWS provider v4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,47 +8,10 @@ resource "aws_s3_bucket" "cache_bucket" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
-  count  = module.this.enabled && local.s3_cache_enabled ? 1 : 0
-  bucket = local.cache_bucket_name_normalised
-  # acl           = "private"
+  count         = module.this.enabled && local.s3_cache_enabled ? 1 : 0
+  bucket        = local.cache_bucket_name_normalised
   force_destroy = true
   tags          = module.this.tags
-
-  # versioning {
-  #   enabled = var.versioning_enabled
-  # }
-
-  # dynamic "logging" {
-  #   for_each = var.access_log_bucket_name != "" ? [1] : []
-  #   content {
-  #     target_bucket = var.access_log_bucket_name
-  #     target_prefix = "logs/${module.this.id}/"
-  #   }
-  # }
-
-  # lifecycle_rule {
-  #   id      = "codebuildcache"
-  #   enabled = true
-
-  #   prefix = "/"
-  #   tags   = module.this.tags
-
-  #   expiration {
-  #     days = var.cache_expiration_days
-  #   }
-  # }
-
-  # dynamic "server_side_encryption_configuration" {
-  #   for_each = var.encryption_enabled ? ["true"] : []
-
-  #   content {
-  #     rule {
-  #       apply_server_side_encryption_by_default {
-  #         sse_algorithm = "AES256"
-  #       }
-  #     }
-  #   }
-  # }
 }
 
 # S3 acl resource support for AWS provider V4

--- a/versions.tf
+++ b/versions.tf
@@ -1,14 +1,14 @@
 terraform {
   required_version = ">= 0.13.0"
 
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.1"
-    }
-  }
+  # required_providers {
+  #   aws = {
+  #     source  = "hashicorp/aws"
+  #     version = ">= 2.0"
+  #   }
+  #   random = {
+  #     source  = "hashicorp/random"
+  #     version = ">= 2.1"
+  #   }
+  # }
 }


### PR DESCRIPTION
## what
* The `aws_s3_bucket` resource has been modified to support AWS provider version 4 and above.
* Every subblock with `aws_s3_bucket` such as server side encryption, acl, lifecycle configuration, replication configuration etc. has its own resource block according to AWS provider v4.

## why
* The `cloudposse/s3-log-storage/aws` module uses AWS provider v4
* All other modules relating to s3 buckets such as `testate-backend`, `s3-website` etc. modules does not support AWS provider v4.
* So the configuration is breaking when used together.
* We upgraded s3 resource to support latest provider.

## references
* It references issue #104 

