### PR TITLE
chore: use numeric instead of number as it's deprecated for random_string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_s3_bucket" "cache_bucket" {
 resource "random_string" "bucket_prefix" {
   count   = module.this.enabled ? 1 : 0
   length  = 12
-  number  = false
+  numeric = false
   upper   = false
   special = false
   lower   = true


### PR DESCRIPTION
## what
* use numeric instead of number as it's deprecated

## why
deprecation warnings

## references
https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string#number

<img width="985" alt="image" src="https://user-images.githubusercontent.com/6103460/174959029-67fb8a9a-334b-4dbc-8076-c416eccba94f.png">
