### PR TITLE
fix(secondary_sources): Error: Reference to undeclared resource

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-codebuild&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-codebuild&utm_content=website
@@ -486,3 +486,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-codebuild
   [share_email]: mailto:?subject=terraform-aws-codebuild&body=https://github.com/cloudposse/terraform-aws-codebuild
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-codebuild?pixel&cs=github&cm=readme&an=terraform-aws-codebuild
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -427,7 +427,7 @@ resource "aws_codebuild_project" "default" {
     }
   }
 
-  dynamic "secondary_sources" {
+  dynamic "secondary_source" {
     for_each = var.secondary_sources
     content {
       git_clone_depth     = secondary_source.value.git_clone_depth

--- a/main.tf
+++ b/main.tf
@@ -437,8 +437,11 @@ resource "aws_codebuild_project" "default" {
       insecure_ssl        = secondary_sources.value.insecure_ssl
       report_build_status = secondary_sources.value.report_build_status
 
-      git_submodules_config {
-        fetch_submodules = secondary_sources.value.fetch_submodules
+      dynamic "git_submodules_config" {
+        for_each = contains(["CODECOMMIT", "GITHUB", "GITHUB_ENTERPRISE"], secondary_sources.value.type) ? [true] : []
+        content {
+          fetch_submodules = secondary_sources.value.fetch_submodules
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -427,18 +427,18 @@ resource "aws_codebuild_project" "default" {
     }
   }
 
-  dynamic "secondary_source" {
+  dynamic "secondary_sources" {
     for_each = var.secondary_sources
     content {
-      git_clone_depth     = secondary_source.value.git_clone_depth
-      location            = secondary_source.value.location
-      source_identifier   = secondary_source.value.source_identifier
-      type                = secondary_source.value.type
-      insecure_ssl        = secondary_source.value.insecure_ssl
-      report_build_status = secondary_source.value.report_build_status
+      git_clone_depth     = secondary_sources.value.git_clone_depth
+      location            = secondary_sources.value.location
+      source_identifier   = secondary_sources.value.source_identifier
+      type                = secondary_sources.value.type
+      insecure_ssl        = secondary_sources.value.insecure_ssl
+      report_build_status = secondary_sources.value.report_build_status
 
       git_submodules_config {
-        fetch_submodules = secondary_source.value.fetch_submodules
+        fetch_submodules = secondary_sources.value.fetch_submodules
       }
     }
   }


### PR DESCRIPTION
## what
* Fixes typo - name of the variable used for provision "secondary sources"
* reduce unnecessary plan/apply output
 
## why
* Failing with error:
```
╷
│ Error: Reference to undeclared resource
│ 
│   on .terraform/modules/cicd.pr_build/main.tf line 438, in resource "aws_codebuild_project" "default":
│  438:       report_build_status = secondary_source.value.report_build_status
│ 
│ A managed resource "secondary_source" "value" has not been declared in module.cicd.module.pr_build.


```
![screenshot](https://user-images.githubusercontent.com/5686014/183632617-8f1a9798-549d-40d7-a310-ff92ab2ef299.png)

* terraform plan was outputting changes to secondary_sources. git_submodules_config even though this is not defined for S3 source type
```
      - secondary_sources {
          - git_clone_depth     = 0 -> null
          - insecure_ssl        = false -> null
          - location            = "XXXX" -> null
          - report_build_status = true -> null
          - source_identifier   = "source2_output" -> null
          - type                = "S3" -> null

          - git_submodules_config {
              - fetch_submodules = false -> null
            }
        }
      + secondary_sources {
          + git_clone_depth     = 0
          + insecure_ssl        = false
          + location            = "XXXX"
          + report_build_status = false
          + source_identifier   = "source2_output"
          + type                = "S3"
        }
```