### PR TITLE
Remove usage of deprecated source.auth

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 module "codebuild" {
   source                      = "../../"
   description                 = "This is my awesome CodeBuild project"
-  concurrent_build_limit      = 10
+  concurrent_build_limit      = 1
   cache_bucket_suffix_enabled = var.cache_bucket_suffix_enabled
   environment_variables       = var.environment_variables
   cache_expiration_days       = var.cache_expiration_days

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -3,20 +3,20 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.21.1"
-  cidr_block = var.vpc_cidr_block
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
 
   context = module.this.context
 }
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.38.0"
+  version              = "2.3.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
+  igw_id               = [module.vpc.igw_id]
+  ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = true
   nat_instance_enabled = false
 

--- a/examples/vpc/versions.tf
+++ b/examples/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -325,7 +325,7 @@ resource "aws_codebuild_project" "default" {
       type                = "S3"
       location            = var.secondary_artifact_location
       artifact_identifier = var.secondary_artifact_identifier
-      encryption_disabled = ! var.secondary_artifact_encryption_enabled
+      encryption_disabled = !var.secondary_artifact_encryption_enabled
       # According to AWS documention, in order to have the artifacts written
       # to the root of the bucket, the 'namespace_type' should be 'NONE'
       # (which is the default), 'name' should be '/', and 'path' should be

--- a/main.tf
+++ b/main.tf
@@ -411,14 +411,6 @@ resource "aws_codebuild_project" "default" {
     report_build_status = var.report_build_status
     git_clone_depth     = var.git_clone_depth != null ? var.git_clone_depth : null
 
-    dynamic "auth" {
-      for_each = var.private_repository ? [""] : []
-      content {
-        type     = "OAUTH"
-        resource = join("", aws_codebuild_source_credential.authorization.*.id)
-      }
-    }
-
     dynamic "git_submodules_config" {
       for_each = var.fetch_git_submodules ? [""] : []
       content {


### PR DESCRIPTION
## what

* Remove usage of deprecated `source.auth` block for `aws_codebuild_project` resource.

## why

The `auth` block for `aws_codebuild_project.source` has been deprecated [since v3.33.0](https://github.com/hashicorp/terraform-provider-aws/pull/17465).

In version 5.0.0 of the AWS provider, the block has been [completely removed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#resourceaws_codebuild_project), so this project fails when trying to use the newer major version of the provider.

According to the [official provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_source_credential), there's no need to replace this block with anything else, as this module already instantiantes a `aws_codebuild_source_credential` resource:

> Codebuild only allows a single credential per given server type in a given region. Therefore, when you define `aws_codebuild_source_credential`, `aws_codebuild_project` resource defined in the same module will use it.